### PR TITLE
Changes to new gh package (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Packages (installed with Homebrew):
   - gettext
   - gifsicle
   - git
-  - github/gh/gh
+  - gh
   - go
   - gpg
   - httpie

--- a/default.config.yml
+++ b/default.config.yml
@@ -42,7 +42,7 @@ homebrew_installed_packages:
   - gettext
   - gifsicle
   - git
-  - github/gh/gh
+  - gh
   - go
   - gpg
   - httpie


### PR DESCRIPTION
Resolves this error:
failed: [localhost] (item=github/gh/gh) => {"ansible_loop_var": "item", "changed": false, "item": "github/gh/gh", "msg": "==> Tapping github/gh\nCloning into '/opt/homebrew/Library/Taps/github/homebrew-gh'...\nTapped (14 files, 55.3KB).\nWarning: Formula github/gh/gh was renamed to gh.\nWarning: No available formula or cask with the name \"github/gh/gh\".\nWarning: Formula github/gh/gh was renamed to gh."}